### PR TITLE
feat: MessageTitle

### DIFF
--- a/cmd/root_runner.go
+++ b/cmd/root_runner.go
@@ -65,7 +65,9 @@ func runRoot(cmd *cobra.Command, args []string) error {
 			return commitErr
 		}
 
-		textErr := text.CheckMessageTitle(commitObject.Message)
+		messageTitle := text.MessageTitle(commitObject.Message)
+
+		textErr := text.CheckMessageTitle(messageTitle)
 
 		if textErr != nil {
 			faultyCommits = append(faultyCommits, commitHash)

--- a/pkg/text/check_message_title.go
+++ b/pkg/text/check_message_title.go
@@ -6,14 +6,14 @@ import (
 )
 
 var (
-	titleRegex         = regexp.MustCompile(`^(?P<type>\w+?)(?P<scope>\(\w+\)?)?!?:\s(?P<message>.+)`)
-	errTitleNonConform = errors.New("message title does not conform to conventional commits")
+	expectedFormatRegex = regexp.MustCompile(`^(?P<type>\w+?)(?P<scope>\(\w+\)?)?!?:\s(?P<message>.+)$`)
+	errTitleNonConform  = errors.New("message title does not conform to conventional commits")
 )
 
 // CheckMessageTitle verifies that the message title conforms to
 // conventional commmit standard https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary
 func CheckMessageTitle(message string) error {
-	match := titleRegex.FindStringSubmatch(message)
+	match := expectedFormatRegex.FindStringSubmatch(message)
 	if match == nil {
 		return errTitleNonConform
 	}

--- a/pkg/text/message_title.go
+++ b/pkg/text/message_title.go
@@ -1,0 +1,17 @@
+package text
+
+import (
+	"regexp"
+	"strings"
+)
+
+var titleRegex = regexp.MustCompile("^.*\n")
+
+// MessageTitle returns only the first line of commit message
+func MessageTitle(message string) string {
+	match := titleRegex.FindString(message)
+
+	match = strings.Replace(match, "\n", "", 1)
+
+	return match
+}

--- a/pkg/text/message_title_test.go
+++ b/pkg/text/message_title_test.go
@@ -1,0 +1,19 @@
+package text
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessageTitle(t *testing.T) {
+	tests := map[string]string{
+		"chore: add something\n":             "chore: add something",
+		"chore: add something\n description": "chore: add something",
+	}
+
+	for test, expected := range tests {
+		err := MessageTitle(test)
+		assert.Equal(t, expected, err)
+	}
+}


### PR DESCRIPTION
- function to strip only the title from commit message

Closes #36 