### PR TITLE
feat: format failing commits

### DIFF
--- a/cmd/root_runner.go
+++ b/cmd/root_runner.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"log"
 
 	"github.com/commitsar-app/commitsar/pkg/history"
@@ -56,7 +57,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 
 	log.Printf("Found %v commit to check", len(commits))
 
-	faultyCommits := []plumbing.Hash{}
+	var faultyCommits []text.FailingCommit
 
 	for _, commitHash := range commits {
 		commitObject, commitErr := repo.CommitObject(commitHash)
@@ -70,14 +71,14 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		textErr := text.CheckMessageTitle(messageTitle)
 
 		if textErr != nil {
-			faultyCommits = append(faultyCommits, commitHash)
+			faultyCommits = append(faultyCommits, text.FailingCommit{Hash: commitHash.String(), Message: messageTitle})
 		}
 	}
 
 	if len(faultyCommits) != 0 {
-		for _, commitHash := range faultyCommits {
-			log.Printf("Commit %v is not conventional commit compliant", commitHash)
-		}
+		failingCommitMessage := text.FormatFailingCommits(faultyCommits)
+
+		fmt.Print(failingCommitMessage)
 
 		log.Printf("%v of %v commits are not conventional commit compliant", len(faultyCommits), len(commits))
 

--- a/pkg/text/format_failing_commits.go
+++ b/pkg/text/format_failing_commits.go
@@ -1,0 +1,29 @@
+package text
+
+import (
+	"strings"
+)
+
+// FailingCommit is just a formatted commit struct
+type FailingCommit struct {
+	Hash    string
+	Message string
+}
+
+// FormatFailingCommits takes in slice of commit hashes and messages and formats it for nice output
+func FormatFailingCommits(commits []FailingCommit) string {
+	builder := strings.Builder{}
+	// Extra spacing to make it nicer
+	builder.WriteString("\nFollowing commits failed the check: \n")
+
+	for _, commit := range commits {
+		builder.WriteString("\n")
+		builder.WriteString("FAIL   ")
+		builder.WriteString(commit.Hash)
+		builder.WriteString("   ")
+		builder.WriteString(commit.Message)
+	}
+
+	builder.WriteString("\n\n")
+	return builder.String()
+}

--- a/pkg/text/format_failing_commits_test.go
+++ b/pkg/text/format_failing_commits_test.go
@@ -1,0 +1,16 @@
+package text
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatFailingCommits(t *testing.T) {
+	var commits []FailingCommit
+
+	commits = append(commits, FailingCommit{Hash: "testhash", Message: "chore:add seomthing"}, FailingCommit{Hash: "testhash2", Message: "broken"})
+
+	formattedText := FormatFailingCommits(commits)
+	assert.Equal(t, formattedText, "\nFollowing commits failed the check: \n\nFAIL   testhash   chore:add seomthing\nFAIL   testhash2   broken\n\n")
+}


### PR DESCRIPTION
- adds nicer formatting for failing commits
- allows user to see which messages failed