### PR TITLE
feat(history)!: Git struct

### DIFF
--- a/pkg/history/open_git.go
+++ b/pkg/history/open_git.go
@@ -1,0 +1,23 @@
+package history
+
+import (
+	"gopkg.in/src-d/go-git.v4"
+)
+
+// Git is the struct used to house all methods in use in Commitsar.
+type Git struct {
+	repo *git.Repository
+	// Debug flag is passed to make debugging easier during development/problematic deploys
+	Debug bool
+}
+
+// OpenGit loads Repo on path and returns a new Git struct to work with.
+func OpenGit(path string, debug bool) (*Git, error) {
+	repo, repoErr := Repo(path)
+
+	if repoErr != nil {
+		return nil, repoErr
+	}
+
+	return &Git{repo: repo, Debug: debug}, nil
+}

--- a/pkg/history/open_git_test.go
+++ b/pkg/history/open_git_test.go
@@ -1,0 +1,22 @@
+package history
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOpenGit(t *testing.T) {
+	git, err := OpenGit("../../", true)
+
+	// Should not error if this git repository is valid
+	assert.NoError(t, err)
+	// Check that debug flag is passed correctly
+	assert.Equal(t, true, git.Debug)
+
+	_, unhappyErr := OpenGit(".", false)
+
+	// Should error opening a folder with missing .git
+	assert.Error(t, unhappyErr)
+
+}


### PR DESCRIPTION
BREAKING CHANGE: OpenGit should be used instead of Git

- OpenGit returns a Git struct which will be used to map all methods to from now on
- This pattern will be used going forward to hide reliance on using go-git directly