### PR TITLE
fix!: Correctly detect commits on branch

### DIFF
--- a/cmd/root_runner.go
+++ b/cmd/root_runner.go
@@ -25,6 +25,12 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		return repoErr
 	}
 
+	gitRepo, err := history.OpenGit(".", true)
+
+	if err != nil {
+		return err
+	}
+
 	currentBranch, currentBranchErr := repo.Head()
 
 	if debug {
@@ -48,7 +54,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		return currentBranchErr
 	}
 
-	commits, commitsErr := history.CommitsOnBranch(repo, currentBranch.Hash(), "origin/master")
+	commits, commitsErr := gitRepo.BranchDiffCommits(currentBranch.Name().String(), "origin/master")
 
 	if commitsErr != nil {
 		return commitsErr

--- a/pkg/history/branch_diff_commits.go
+++ b/pkg/history/branch_diff_commits.go
@@ -1,55 +1,51 @@
 package history
 
 import (
-	"fmt"
-
 	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/object"
 )
 
-// BranchDiffCommits finds the common ancestors between two branches
-// Flow:
-// 1. Find latest commit on branchA
-// 2. Find latest commit on branchB
-// 3. Run MergeBase against them
-func (g *Git) BranchDiffCommits(branchA string, branchB string) ([]*object.Commit, error) {
-	branchACommit, err := g.latestCommitOnBranch(branchA)
+// BranchDiffCommits compares commits from 2 branches and returns of a diff of them.
+func (g *Git) BranchDiffCommits(branchA string, branchB string) ([]plumbing.Hash, error) {
+	branchACommit, err := g.LatestCommitOnBranch(branchA)
 
 	if err != nil {
 		return nil, err
 	}
 
-	branchBCommit, err := g.latestCommitOnBranch(branchB)
+	branchBCommit, err := g.LatestCommitOnBranch(branchB)
 
 	if err != nil {
 		return nil, err
 	}
 
-	diffCommits, mergeBaseErr := branchACommit.MergeBase(branchBCommit)
+	branchACommits, err := g.CommitsOnBranch(branchACommit.Hash)
 
-	if mergeBaseErr != nil {
-		return nil, mergeBaseErr
+	if err != nil {
+		return nil, err
 	}
 
-	if g.Debug {
-		fmt.Printf("\n Following mergeCommits found %v", diffCommits)
+	branchBCommits, err := g.CommitsOnBranch(branchBCommit.Hash)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var diffCommits []plumbing.Hash
+
+	for _, commit := range branchACommits {
+		if !contains(branchBCommits, commit) {
+			diffCommits = append(diffCommits, commit)
+		}
 	}
 
 	return diffCommits, nil
 }
 
-func (g *Git) latestCommitOnBranch(desiredBranch string) (*object.Commit, error) {
-	desiredHash, err := g.repo.ResolveRevision(plumbing.Revision(desiredBranch))
-
-	if err != nil {
-		return nil, err
+func contains(s []plumbing.Hash, e plumbing.Hash) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
 	}
-
-	desiredCommit, err := g.repo.CommitObject(*desiredHash)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return desiredCommit, nil
+	return false
 }

--- a/pkg/history/branch_diff_commits_test.go
+++ b/pkg/history/branch_diff_commits_test.go
@@ -4,16 +4,36 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/src-d/go-git.v4"
 )
 
 func TestBranchDiffCommits(t *testing.T) {
 	repo := setupRepo()
 	createTestHistory(repo)
 
-	git := &Git{repo: repo}
+	testGit := &Git{repo: repo}
 
-	commits, err := git.BranchDiffCommits("my-branch", "master")
+	commits, err := testGit.BranchDiffCommits("my-branch", "master")
+
+	commit, _ := repo.CommitObject(commits[0])
 
 	assert.NoError(t, err)
-	assert.Equal(t, "test commit on master", commits[0].Message)
+	assert.Equal(t, "third commit on new branch", commit.Message)
+	assert.Equal(t, 3, len(commits))
+}
+
+func TestBranchDiffCommitsWithMasterMerge(t *testing.T) {
+	repo, _ := git.PlainOpen("../../testdata/commits_on_branch_test")
+	testGit := &Git{repo: repo, Debug: true}
+
+	commits, err := testGit.BranchDiffCommits("behind-master", "master")
+
+	assert.Equal(t, 2, len(commits))
+
+	commit, _ := repo.CommitObject(commits[1])
+
+	assert.Equal(t, "first commit on branch\n", commit.Message)
+
+	assert.Equal(t, err, nil)
+
 }

--- a/pkg/history/commits_on_branch.go
+++ b/pkg/history/commits_on_branch.go
@@ -11,77 +11,29 @@ import (
 // ErrCommonCommitFound is used for identifying when the iterator has reached the common commit
 var ErrCommonCommitFound = errors.New("common commit found")
 
-// CommitsOnBranch iterates through all references and returns commit hashes on given branch
-func CommitsOnBranch(
-	repo *git.Repository,
-	branchHash plumbing.Hash,
-	compareBranch string,
+// CommitsOnBranch iterates through all references and returns commit hashes on given branch. \n
+// Important to note is that this will provide all commits from anything the branch is connected to.
+func (g *Git) CommitsOnBranch(
+	branchCommit plumbing.Hash,
 ) ([]plumbing.Hash, error) {
+	var branchCommits []plumbing.Hash
 
-	var commits []plumbing.Hash
-
-	// common ancestor between two branches based on MergeBase
-	var commonHash plumbing.Hash
-
-	branchCommit, err := repo.CommitObject(branchHash)
-
-	if err != nil {
-		return nil, err
-	}
-
-	compareCommit, err := commitFromRepo(repo, compareBranch)
-
-	if err != nil {
-		return nil, err
-	}
-
-	diffCommits, mergeBaseErr := branchCommit.MergeBase(compareCommit)
-
-	if mergeBaseErr != nil {
-		return nil, mergeBaseErr
-	}
-
-	commonHash = diffCommits[len(diffCommits)-1].Hash
-
-	commitIter, logErr := repo.Log(&git.LogOptions{
-		Order: git.LogOrderCommitterTime,
-		From:  branchCommit.Hash,
+	branchIter, err := g.repo.Log(&git.LogOptions{
+		From: branchCommit,
 	})
 
-	if logErr != nil {
-		return nil, logErr
+	if err != nil {
+		return nil, err
 	}
 
-	iterErr := commitIter.ForEach(func(commit *object.Commit) error {
-		if commit.Hash == commonHash {
-			return ErrCommonCommitFound
-		}
-		commits = append(commits, commit.Hash)
+	branchIterErr := branchIter.ForEach(func(commit *object.Commit) error {
+		branchCommits = append(branchCommits, commit.Hash)
 		return nil
 	})
 
-	if iterErr != nil {
-		if iterErr == ErrCommonCommitFound {
-			return commits, nil
-		}
-		return nil, iterErr
+	if branchIterErr != nil {
+		return nil, branchIterErr
 	}
 
-	return commits, nil
-}
-
-func commitFromRepo(repo *git.Repository, desiredBranch string) (*object.Commit, error) {
-	desiredHash, err := repo.ResolveRevision(plumbing.Revision(desiredBranch))
-
-	if err != nil {
-		return nil, err
-	}
-
-	desiredCommit, err := repo.CommitObject(*desiredHash)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return desiredCommit, nil
+	return branchCommits, nil
 }

--- a/pkg/history/commits_on_branch_test.go
+++ b/pkg/history/commits_on_branch_test.go
@@ -44,11 +44,13 @@ func TestCommitsOnBranch(t *testing.T) {
 	repo := setupRepo()
 	createTestHistory(repo)
 
-	headRef, _ := repo.Head()
+	head, _ := repo.Head()
 
-	commits, err := CommitsOnBranch(repo, headRef.Hash(), "master")
+	testGit := &Git{repo: repo}
 
-	assert.Equal(t, 3, len(commits))
+	commits, err := testGit.CommitsOnBranch(head.Hash())
+
+	assert.Equal(t, 4, len(commits))
 
 	commit, commitErr := repo.CommitObject(commits[0])
 
@@ -56,24 +58,7 @@ func TestCommitsOnBranch(t *testing.T) {
 	assert.Equal(t, "third commit on new branch", commit.Message)
 	assert.Equal(t, err, nil)
 
-}
+	lastCommit, _ := repo.CommitObject(commits[3])
 
-func TestCommitsOnBranchWithMasterMerge(t *testing.T) {
-	repo, _ := git.PlainOpen("../../testdata/commits_on_branch_test")
-	headRef, _ := repo.Head()
-
-	commits, err := CommitsOnBranch(repo, headRef.Hash(), "master")
-
-	assert.Equal(t, 2, len(commits))
-
-	lastCommit, lastCommitErr := repo.CommitObject(commits[0])
-	assert.NoError(t, lastCommitErr)
-	assert.Equal(t, "Merge branch 'master' into behind-master\n", lastCommit.Message)
-
-	penultimateCommit, penultimateCommitErr := repo.CommitObject(commits[1])
-	assert.NoError(t, penultimateCommitErr)
-	assert.Equal(t, "first commit on behind-master branch\n", penultimateCommit.Message)
-
-	assert.Equal(t, err, nil)
-
+	assert.Equal(t, "test commit on master", lastCommit.Message)
 }

--- a/pkg/history/latest_commit_on_branch.go
+++ b/pkg/history/latest_commit_on_branch.go
@@ -1,0 +1,23 @@
+package history
+
+import (
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+// LatestCommitOnBranch resolves a revision and then returns the latest commit on it.
+func (g *Git) LatestCommitOnBranch(desiredBranch string) (*object.Commit, error) {
+	desiredHash, err := g.repo.ResolveRevision(plumbing.Revision(desiredBranch))
+
+	if err != nil {
+		return nil, err
+	}
+
+	desiredCommit, err := g.repo.CommitObject(*desiredHash)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return desiredCommit, nil
+}

--- a/pkg/history/latest_commit_on_branch_test.go
+++ b/pkg/history/latest_commit_on_branch_test.go
@@ -1,0 +1,22 @@
+package history
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLatestCommitOnBranch(t *testing.T) {
+	repo := setupRepo()
+	createTestHistory(repo)
+
+	head, _ := repo.Head()
+
+	testGit := &Git{repo: repo}
+
+	commit, err := testGit.LatestCommitOnBranch(head.Name().String())
+
+	assert.NoError(t, err)
+	assert.Equal(t, "third commit on new branch", commit.Message)
+	assert.Equal(t, err, nil)
+}

--- a/scripts/setup_commits_on_branch_test.sh
+++ b/scripts/setup_commits_on_branch_test.sh
@@ -16,11 +16,16 @@ if [ ! -d './testdata/commits_on_branch_test' ]; then
   git add .
   git commit -m "second commit on master"
   git checkout -b behind-master
-  git reset HEAD~1
-  git checkout -- .
   touch third
   git add .
-  git commit -m "first commit on behind-master branch"
+  git commit -m "first commit on branch"
+  git checkout master
+  # Because this script is so fast it will actual provide false positives without this sleep
+  sleep 1
+  touch four
+  git add .
+  git commit -m "third commit on master"
+  git checkout behind-master
   git merge master --no-edit
   echo 'done'
   


### PR DESCRIPTION
BREAKING CHANGE: CommitsOnBranch is completely reworked to use a different method of getting commits. It no longer provides a diff and returns only Commits on branch

- Reworked CommitsOnBranch
- Reworked BranchDiffCommits to not use merge base anymore but to provide a diff of commits between branches
- Exposed LatestCommitsOnBranch
- Adjusted rootRunner to use new methods