### PR TITLE
feat: CommitsBetween

### DIFF
--- a/pkg/history/commits_between.go
+++ b/pkg/history/commits_between.go
@@ -1,0 +1,40 @@
+package history
+
+import (
+	"errors"
+
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+var (
+	errReachedToCommit = errors.New("reached to commit")
+)
+
+// CommitsBetween returns a slice of commit hashes between two commits
+func (g *Git) CommitsBetween(from plumbing.Hash, to plumbing.Hash) ([]plumbing.Hash, error) {
+	cIter, _ := g.repo.Log(&git.LogOptions{From: from})
+
+	var commits []plumbing.Hash
+
+	err := cIter.ForEach(func(c *object.Commit) error {
+		// If no previous tag is found then from and to are equal
+		if from == to {
+			return nil
+		}
+		if c.Hash == to {
+			return errReachedToCommit
+		}
+		commits = append(commits, c.Hash)
+		return nil
+	})
+
+	if err == errReachedToCommit {
+		return commits, nil
+	}
+	if err != nil {
+		return commits, err
+	}
+	return commits, nil
+}

--- a/pkg/history/commits_between_test.go
+++ b/pkg/history/commits_between_test.go
@@ -1,0 +1,37 @@
+package history
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/src-d/go-git.v4"
+)
+
+func TestCommitsBetween(t *testing.T) {
+	repo, _ := git.PlainOpen("../../testdata/git_tags")
+	testGit := &Git{repo: repo, Debug: false}
+
+	head, err := repo.Head()
+
+	assert.NoError(t, err)
+
+	tagHash, err := testGit.PreviousTag(head.Hash())
+
+	assert.NoError(t, err)
+
+	log.Print(tagHash)
+
+	commit, err := repo.CommitObject(tagHash)
+	assert.NoError(t, err)
+	assert.Equal(t, "chore: first commit on master\n", commit.Message)
+
+	commits, err := testGit.CommitsBetween(head.Hash(), tagHash)
+
+	assert.NoError(t, err)
+	assert.Len(t, commits, 3)
+
+	middleCommit, _ := repo.CommitObject(commits[1])
+
+	assert.Equal(t, "chore: third commit on master\n", middleCommit.Message)
+}


### PR DESCRIPTION
- CommitsBetween iterates through commits from `git log` and returns them until it reaches a `to` stopping point