### PR TITLE
fix: Use Committer date instead of Author

### DIFF
--- a/pkg/history/commit_date.go
+++ b/pkg/history/commit_date.go
@@ -14,7 +14,7 @@ func (g *Git) commitDate(commit plumbing.Hash) (time.Time, error) {
 		return time.Now(), err
 	}
 
-	when := commitObject.Author.When
+	when := commitObject.Committer.When
 
 	return when, nil
 }


### PR DESCRIPTION
- Committer should always be the latest as it is the dare when the commit is actually made