### PR TITLE
feat: ParseCommit and Error levels

### DIFF
--- a/cmd/root_runner.go
+++ b/cmd/root_runner.go
@@ -72,7 +72,9 @@ func runRoot(cmd *cobra.Command, args []string) error {
 
 		messageTitle := text.MessageTitle(commitObject.Message)
 
-		textErr := text.CheckMessageTitle(messageTitle)
+		parsedCommit := text.ParseCommit(commitObject.Message, commitHash)
+
+		textErr := text.CheckMessageTitle(parsedCommit)
 
 		if textErr != nil {
 			faultyCommits = append(faultyCommits, text.FailingCommit{Hash: commitHash.String(), Message: messageTitle})

--- a/pkg/text/check_message_title.go
+++ b/pkg/text/check_message_title.go
@@ -6,16 +6,30 @@ import (
 )
 
 var (
-	expectedFormatRegex = regexp.MustCompile(`^(?P<type>\w+?)(?P<scope>\(\w+\)?)?!?:\s(?P<message>.+)$`)
-	errTitleNonConform  = errors.New("message title does not conform to conventional commits")
+	errCategoryMissing     = errors.New("category missing")
+	errCategoryWrongFormat = errors.New("category wrong format")
+	errScopeNonConform     = errors.New("malformed scope")
+
+	// Fields such as category and chore should contain only word characters
+	fieldRegex = regexp.MustCompile(`^\w+$`)
 )
 
 // CheckMessageTitle verifies that the message title conforms to
 // conventional commmit standard https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary
-func CheckMessageTitle(message string) error {
-	match := expectedFormatRegex.FindStringSubmatch(message)
-	if match == nil {
-		return errTitleNonConform
+func CheckMessageTitle(commit Commit) error {
+	if commit.Category == "" {
+		return errCategoryMissing
 	}
+	categoryMatch := fieldRegex.FindStringSubmatch(commit.Category)
+
+	if categoryMatch == nil {
+		return errCategoryWrongFormat
+	}
+
+	scopeMatch := fieldRegex.FindStringSubmatch(commit.Scope)
+	if commit.Scope != "" && scopeMatch == nil {
+		return errScopeNonConform
+	}
+
 	return nil
 }

--- a/pkg/text/check_message_title_test.go
+++ b/pkg/text/check_message_title_test.go
@@ -7,19 +7,19 @@ import (
 )
 
 func TestCheckMessageTitle(t *testing.T) {
-	tests := map[string]error{
-		"chore: add something":               nil,
-		"chore(ci): added new CI stuff":      nil,
-		"feat: added a new feature":          nil,
-		"fix!: breaking change":              nil,
-		"fix(security)!: breaking":           nil,
-		"fix!!: breaking":                    errTitleNonConform,
-		"fix(security)(stuff): should break": errTitleNonConform,
-		"chore:really close":                 errTitleNonConform,
-		"perf(): nope":                       errTitleNonConform,
-		"chore(: bad":                        errTitleNonConform,
-		": nope":                             errTitleNonConform,
-		"fix tests":                          errTitleNonConform,
+	tests := map[Commit]error{
+		Commit{Category: "chore", Heading: "add something"}:                             nil,
+		Commit{Category: "chore", Scope: "ci", Heading: "added new CI stuff"}:           nil,
+		Commit{Category: "feat", Heading: "added a new feature"}:                        nil,
+		Commit{Category: "fix", Breaking: true, Heading: "breaking change"}:             nil,
+		Commit{Category: "fix", Scope: "security", Breaking: true, Heading: "breaking"}: nil,
+		Commit{Category: "fix!", Breaking: true, Heading: "breaking"}:                   errCategoryWrongFormat,
+		Commit{Category: "fix", Scope: "security(stuff)", Heading: "should break"}:      errScopeNonConform,
+		Commit{}: errCategoryMissing,
+		Commit{Category: "perf()", Heading: "nope"}: errCategoryWrongFormat,
+		Commit{Category: "chore(", Heading: "bad"}:  errCategoryWrongFormat,
+		Commit{Heading: "nope"}:                     errCategoryMissing,
+		Commit{Category: "test", Scope: "full", Heading: "a heading", Body: "body is here\nit can have multiple lines"}: nil,
 	}
 
 	for test, expected := range tests {

--- a/pkg/text/commit.go
+++ b/pkg/text/commit.go
@@ -1,0 +1,12 @@
+package text
+
+// Commit is a parsed commit message + hash of the commit
+type Commit struct {
+	Category string
+	Scope    string
+	Breaking bool
+	Heading  string
+	Body     string
+	Footer   string
+	Hash     [20]byte
+}

--- a/pkg/text/parse_commit.go
+++ b/pkg/text/parse_commit.go
@@ -1,0 +1,44 @@
+package text
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	expectedFormatRegex = regexp.MustCompile(`(?s)^(?P<category>\S+?)?(?P<scope>\(\S+\))?(?P<breaking>!?)?: (?P<heading>[^\n\r]+)?([\n\r]{2}(?P<body>.*))?`)
+)
+
+// ParseCommit takes a commits message and parses it into usable blocks
+func ParseCommit(message string, hash [20]byte) Commit {
+	match := expectedFormatRegex.FindStringSubmatch(message)
+
+	if len(match) == 0 {
+		return Commit{}
+	}
+
+	result := make(map[string]string)
+	for i, name := range expectedFormatRegex.SubexpNames() {
+		if i != 0 && name != "" {
+			result[name] = match[i]
+		}
+	}
+
+	scope := result["scope"]
+
+	// strip brackets from scope if present
+	if scope != "" {
+		scope = strings.Replace(scope, "(", "", 1)
+		scope = strings.Replace(scope, ")", "", 1)
+	}
+
+	return Commit{
+		Category: result["category"],
+		Scope:    scope,
+		Breaking: result["breaking"] == "!",
+		Heading:  result["heading"],
+		Body:     result["body"],
+		Footer:   "",
+		Hash:     hash,
+	}
+}

--- a/pkg/text/parse_commit_test.go
+++ b/pkg/text/parse_commit_test.go
@@ -1,0 +1,32 @@
+package text
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCommit(t *testing.T) {
+	var testHash [20]byte
+
+	tests := map[string]Commit{
+		"chore: add something\n":               Commit{Category: "chore", Heading: "add something", Hash: testHash},
+		"chore(ci): added new CI stuff\n":      Commit{Category: "chore", Scope: "ci", Heading: "added new CI stuff", Hash: testHash},
+		"feat: added a new feature\n":          Commit{Category: "feat", Heading: "added a new feature"},
+		"fix!: breaking change\n":              Commit{Category: "fix", Breaking: true, Heading: "breaking change"},
+		"fix(security)!: breaking\n":           Commit{Category: "fix", Scope: "security", Breaking: true, Heading: "breaking"},
+		"fix!!: breaking\n":                    Commit{Category: "fix!", Breaking: true, Heading: "breaking"},
+		"fix(security)(stuff): should break\n": Commit{Category: "fix", Scope: "security(stuff)", Heading: "should break"},
+		"chore:really close\n":                 Commit{},
+		"perf(): nope\n":                       Commit{Category: "perf()", Heading: "nope"},
+		"chore(: bad\n":                        Commit{Category: "chore(", Heading: "bad"},
+		": nope\n":                             Commit{Heading: "nope"},
+		"fix tests\n":                          Commit{},
+		"test(full): a heading\n\nbody is here\nit can have multiple lines": Commit{Category: "test", Scope: "full", Heading: "a heading", Body: "body is here\nit can have multiple lines"},
+	}
+
+	for test, expected := range tests {
+		err := ParseCommit(test, testHash)
+		assert.Equal(t, expected, err)
+	}
+}


### PR DESCRIPTION
- adds ParseCommit functionality
- adds custom Commit struct
- adds levels of error to check_message_title