### PR TITLE
feat: breaking change errors

### DIFF
--- a/pkg/text/check_message_title.go
+++ b/pkg/text/check_message_title.go
@@ -9,9 +9,14 @@ var (
 	errCategoryMissing     = errors.New("category missing")
 	errCategoryWrongFormat = errors.New("category wrong format")
 	errScopeNonConform     = errors.New("malformed scope")
+	errMissingBCBody       = errors.New("breaking change must contain commit body")
+	errBCMissingText       = errors.New("breaking change commit body must start with BREAKING CHANGE: ")
 
 	// Fields such as category and chore should contain only word characters
 	fieldRegex = regexp.MustCompile(`^\w+$`)
+
+	// Commits with breaking changes should contain text with BREAKING CHANGE: at start
+	bcRegex = regexp.MustCompile(`^BREAKING CHANGE: `)
 )
 
 // CheckMessageTitle verifies that the message title conforms to
@@ -29,6 +34,16 @@ func CheckMessageTitle(commit Commit) error {
 	scopeMatch := fieldRegex.FindStringSubmatch(commit.Scope)
 	if commit.Scope != "" && scopeMatch == nil {
 		return errScopeNonConform
+	}
+
+	if commit.Breaking {
+		if commit.Body == "" {
+			return errMissingBCBody
+		}
+		bcMatch := bcRegex.FindStringSubmatch(commit.Body)
+		if bcMatch == nil {
+			return errBCMissingText
+		}
 	}
 
 	return nil

--- a/pkg/text/check_message_title_test.go
+++ b/pkg/text/check_message_title_test.go
@@ -11,8 +11,8 @@ func TestCheckMessageTitle(t *testing.T) {
 		Commit{Category: "chore", Heading: "add something"}:                             nil,
 		Commit{Category: "chore", Scope: "ci", Heading: "added new CI stuff"}:           nil,
 		Commit{Category: "feat", Heading: "added a new feature"}:                        nil,
-		Commit{Category: "fix", Breaking: true, Heading: "breaking change"}:             nil,
-		Commit{Category: "fix", Scope: "security", Breaking: true, Heading: "breaking"}: nil,
+		Commit{Category: "fix", Breaking: true, Heading: "breaking change"}:             errMissingBCBody,
+		Commit{Category: "fix", Scope: "security", Breaking: true, Heading: "breaking"}: errMissingBCBody,
 		Commit{Category: "fix!", Breaking: true, Heading: "breaking"}:                   errCategoryWrongFormat,
 		Commit{Category: "fix", Scope: "security(stuff)", Heading: "should break"}:      errScopeNonConform,
 		Commit{}: errCategoryMissing,
@@ -20,6 +20,8 @@ func TestCheckMessageTitle(t *testing.T) {
 		Commit{Category: "chore(", Heading: "bad"}:  errCategoryWrongFormat,
 		Commit{Heading: "nope"}:                     errCategoryMissing,
 		Commit{Category: "test", Scope: "full", Heading: "a heading", Body: "body is here\nit can have multiple lines"}: nil,
+		Commit{Category: "test", Heading: "a heading", Body: "body is here", Breaking: true}:                            errBCMissingText,
+		Commit{Category: "test", Heading: "a heading", Body: "BREAKING CHANGE: this happened", Breaking: true}:          nil,
 	}
 
 	for test, expected := range tests {


### PR DESCRIPTION
- check_message_title will now warn when breaking change is missing a commit body
- check_message_title will now error when BC body does not start with BREAKING CHANGE:

Closes #34 