### PR TITLE
fix: prepend origin in compare branch name

### DIFF
--- a/internal/providers/find_compare_branch.go
+++ b/internal/providers/find_compare_branch.go
@@ -1,15 +1,21 @@
 package providers
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 // FindCompareBranch tries to find the merge request compare branch based on environment variables used by different CIs.
 func FindCompareBranch() string {
-	if os.Getenv("GITHUB_BASE_REF") != "" {
-		return os.Getenv("GITHUB_BASE_REF")
+	githubRef := os.Getenv("GITHUB_BASE_REF")
+
+	if githubRef != "" {
+		return fmt.Sprintf("origin/%v", githubRef)
 	}
 
-	if os.Getenv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME") != "" {
-		return os.Getenv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME")
+	gitlabRef := os.Getenv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME")
+	if gitlabRef != "" {
+		return fmt.Sprintf("origin/%v", gitlabRef)
 	}
 
 	return "origin/master"

--- a/internal/providers/find_compare_branch_test.go
+++ b/internal/providers/find_compare_branch_test.go
@@ -13,7 +13,7 @@ func TestFindCompareBranch(t *testing.T) {
 
 	actionCompareBranch := FindCompareBranch()
 
-	assert.Equal(t, "github-develop", actionCompareBranch)
+	assert.Equal(t, "origin/github-develop", actionCompareBranch)
 
 	os.Setenv("GITHUB_BASE_REF", "")
 
@@ -22,7 +22,7 @@ func TestFindCompareBranch(t *testing.T) {
 
 	gitlabCompareBranch := FindCompareBranch()
 
-	assert.Equal(t, "gitlab-develop", gitlabCompareBranch)
+	assert.Equal(t, "origin/gitlab-develop", gitlabCompareBranch)
 
 	os.Setenv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME", "")
 


### PR DESCRIPTION
- without origin go-git would not resolve the branch name