### PR TITLE
feat!: Add strict mode

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,11 +19,15 @@ var rootCmd = &cobra.Command{
 // Verbose is used to allow verbose/debug output for any given command
 var Verbose bool
 
+// Strict is used to enforce only standard categories
+var Strict bool
+
 // Dir is the location of repo to check
 var Dir string
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+	rootCmd.PersistentFlags().BoolVarP(&Strict, "strict", "s", true, "strict mode")
 	rootCmd.PersistentFlags().StringVarP(&Dir, "path", "d", ".", "dir points to the path of the repository")
 }
 

--- a/cmd/root_runner.go
+++ b/cmd/root_runner.go
@@ -18,6 +18,11 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		debug = true
 	}
 
+	strict := true
+	if cmd.Flag("strict").Value.String() == "false" {
+		strict = false
+	}
+
 	fmt.Print("Starting analysis of commits on branch\n")
 
 	gitRepo, err := history.OpenGit(".", debug)
@@ -77,7 +82,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 
 		parsedCommit := text.ParseCommit(commitObject.Message, commitHash)
 
-		textErr := text.CheckMessageTitle(parsedCommit)
+		textErr := text.CheckMessageTitle(parsedCommit, strict)
 
 		if textErr != nil {
 			faultyCommits = append(faultyCommits, text.FailingCommit{Hash: commitHash.String(), Message: messageTitle, Error: textErr})

--- a/pkg/text/check_message_title.go
+++ b/pkg/text/check_message_title.go
@@ -3,11 +3,13 @@ package text
 import (
 	"errors"
 	"regexp"
+	"strings"
 )
 
 var (
 	errCategoryMissing     = errors.New("category missing")
 	errCategoryWrongFormat = errors.New("category wrong format")
+	errNonStandardCategory = errors.New("category not one of " + strings.Join(allowedCategories[:], ","))
 	errScopeNonConform     = errors.New("malformed scope")
 	errMissingBCBody       = errors.New("breaking change must contain commit body")
 	errBCMissingText       = errors.New("breaking change commit body must start with BREAKING CHANGE: ")
@@ -17,11 +19,24 @@ var (
 
 	// Commits with breaking changes should contain text with BREAKING CHANGE: at start
 	bcRegex = regexp.MustCompile(`^BREAKING CHANGE: `)
+
+	// Types allowed by the Angular contributing guide
+	allowedCategories = []string{"build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"}
 )
+
+func isAllowedCategory(category string) bool {
+	for _, val := range allowedCategories {
+		if val == category {
+			return true
+		}
+	}
+
+	return false
+}
 
 // CheckMessageTitle verifies that the message title conforms to
 // conventional commmit standard https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary
-func CheckMessageTitle(commit Commit) error {
+func CheckMessageTitle(commit Commit, strict bool) error {
 	if commit.Category == "" {
 		return errCategoryMissing
 	}
@@ -29,6 +44,10 @@ func CheckMessageTitle(commit Commit) error {
 
 	if categoryMatch == nil {
 		return errCategoryWrongFormat
+	}
+
+	if strict && !isAllowedCategory(categoryMatch[0]) {
+		return errNonStandardCategory
 	}
 
 	scopeMatch := fieldRegex.FindStringSubmatch(commit.Scope)

--- a/pkg/text/check_message_title_test.go
+++ b/pkg/text/check_message_title_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCheckMessageTitle(t *testing.T) {
+func TestCheckMessageTitleNonStrict(t *testing.T) {
 	tests := map[Commit]error{
 		Commit{Category: "chore", Heading: "add something"}:                             nil,
 		Commit{Category: "chore", Scope: "ci", Heading: "added new CI stuff"}:           nil,
@@ -25,7 +25,22 @@ func TestCheckMessageTitle(t *testing.T) {
 	}
 
 	for test, expected := range tests {
-		err := CheckMessageTitle(test)
+		err := CheckMessageTitle(test, false)
+		assert.Equal(t, expected, err)
+	}
+}
+
+func TestCheckMessageTitleStrict(t *testing.T) {
+	tests := make(map[Commit]error)
+
+	for _, cat := range allowedCategories {
+		tests[Commit{Category: cat, Heading: "add something"}] = nil
+	}
+
+	tests[Commit{Category: "thisshouldneverbeacategory", Heading: "add something"}] = errNonStandardCategory
+
+	for test, expected := range tests {
+		err := CheckMessageTitle(test, true)
 		assert.Equal(t, expected, err)
 	}
 }


### PR DESCRIPTION
This mode makes sure that the category is one of the currently
defined categories in Angular's contributing guide.

{"build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"}

It's true by default, as it serves better most of the cases where
an opinionated style guide is used.

Closes #31 